### PR TITLE
Fix Error: Could not find parent resource type '::params'

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,7 +46,7 @@ class phpfpm (
   $apcpackage             = $phpfpm::params::apcpackage,
   $service                = $phpfpm::params::service,
   $config                 = $phpfpm::params::config
-  ) inherits params {
+  ) inherits phpfpm::params {
 
 
   $serviceensure = $ensure ? {


### PR DESCRIPTION
Trying to fix "Error: Could not find parent resource type '::params'" on Puppet 4.x
